### PR TITLE
Show a warning prompt when closing main window

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -74,8 +74,14 @@ app.on('ready', function() {
     // TODO: these are tests
     mainWindow.webSecurity = false;
 
-    mainWindow.onbeforeunload = () => {};
-    
+    mainWindow.on('close', function(evt) {
+        const choice = electron.dialog.showMessageBox({message: 'Really quit Snap? Unsaved changes will be lost!', buttons: ['Cancel', 'Quit']});
+
+        if (choice === 0) {
+            evt.preventDefault();
+        }
+    });
+
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {
         // Dereference the window object, usually you would store windows


### PR DESCRIPTION
Resolves #9 by showing a warning prompt when the user tries to close the window:

![A prompt dialog: "Really quit Snap? Unsaved changes will be lost!"](https://user-images.githubusercontent.com/9948030/50504251-a2fb2c80-0a42-11e9-87c6-f85bb83c6b04.png)

The main thing I'm worried about with this change is translation -- this message is hard-coded. But I don't think there's currently any way to access translations in the Snap! app, and implementing something like that would be out of the scope of this PR.

Note - this prompt shows up no matter how the window is closed - even if it's from pressing Ctrl-C at the command line. This makes development a little more involved (since you have to click "close" each time you reload). Snap<i>!</i> (in the browser) doesn't seem to have a condition for whether or not to warn before closing ([it always warns](https://github.com/jmoenig/Snap/blob/258e476e5fd8e1646a54f86f38108e6553fabee2/src/morphic.js#L12080-L12089)), so we can't make use of anything like that. And Electron doesn't seem to tell us whether the event came from pressing quit or Ctrl-C - so I don't see any obvious way to make it not prompt on Ctrl-C.