### PR TITLE
Add Ctrl/Cmd-Q keyboard shortcut to quit

### DIFF
--- a/app/snap-app/gui.js
+++ b/app/snap-app/gui.js
@@ -3,89 +3,84 @@ const fs = require('fs');
 const path = require('path');
 const url = require('url');
 
-const {nativeImage} = require('electron');
+const {nativeImage, remote} = require('electron');
 
-// Hold Proxied Functions
-// TODO: Consider using ES6 Proxies?
-GLOBAL_DEFINITIONS = {};
-
-function originalMethod(functionName) {
-    return GLOBAL_DEFINITIONS[functionName];
+function defineProxy(cls, functionName, makeFunctionBody) {
+    cls.prototype[functionName] = makeFunctionBody(cls.prototype[functionName]);
 }
 
-function defineProxy(functionName, functionBody) {
-    GLOBAL_DEFINITIONS[functionName] = IDE_Morph.prototype[functionName];
-    IDE_Morph.prototype[functionName] = functionBody;
-    return functionName;
-}
+defineProxy(IDE_Morph, 'saveFileAs', () => {
+    return function (contents, fileType, fileName, newWindow) {
+        var blobIsSupported = false,
+            myself = this,
+            fileExt;
 
-defineProxy('saveFileAs',
-            function (contents, fileType, fileName, newWindow) {
-    var blobIsSupported = false,
-        myself = this,
-        fileExt;
+        // fileType is a <kind>/<ext>;<charset> format.
+        fileExt = fileType.split('/')[1].split(';')[0];
+        // handle text/plain as a .txt file
+        fileExt = '.' + (fileExt === 'plain' ? 'txt' : fileExt);
 
-    // fileType is a <kind>/<ext>;<charset> format.
-    fileExt = fileType.split('/')[1].split(';')[0];
-    // handle text/plain as a .txt file
-    fileExt = '.' + (fileExt === 'plain' ? 'txt' : fileExt);
-
-    // This is a workaround for a known Chrome crash with large URLs
-    // TODO: Verify whether this is necessary in Electron
-    function exhibitsChomeBug(contents) {
-        var MAX_LENGTH = 2e6,
-        isChrome  = navigator.userAgent.indexOf('Chrome') !== -1;
-        return isChrome && contents.length > MAX_LENGTH;
-    }
-
-    // saveFile(fileName, fileContents);
-    
-    // Convert images to node Buffers
-    // TODO: Handle other formats (sound?)
-    if (fileExt === '.png') {
-        img = nativeImage.createFromDataURL(contents);
-        contents = img.toPng();
-    }
-    // save As Stuff
-    // TODO: Show a dialog, but that doesn't work?
-    // TODO: What to do about encoding?
-    
-    fs.writeFile(fileName + fileExt, contents, function (err, resp) {
-        if (err) {
-            console.log('Error! ', err);
-            myself.showMessage('Oh Noes!' + err);
-        } else {
-            console.log('Saved??');
-            myself.showMessage('Saved!');
+        // This is a workaround for a known Chrome crash with large URLs
+        // TODO: Verify whether this is necessary in Electron
+        function exhibitsChomeBug(contents) {
+            var MAX_LENGTH = 2e6,
+            isChrome  = navigator.userAgent.indexOf('Chrome') !== -1;
+            return isChrome && contents.length > MAX_LENGTH;
         }
-    });
-    
-    // This doesn't work right now, because it's the wrong electron "context"
-    // var dialog = require('electron').dialog;
-    // dialog.showSaveDialog({ filters: [
-    //    { name: 'text', extensions: ['txt'] }
-    //   ]}, function (fileName) {
-    //   if (fileName === undefined) return;
-    //   fs.writeFile(fileName, fContents, function (err) {
-    //    dialog.showMessageBox({ message: "The file has been saved! :-)",
-    //     buttons: ["OK"] });
-    //   });
-    // });
-})
+
+        // saveFile(fileName, fileContents);
+
+        // Convert images to node Buffers
+        // TODO: Handle other formats (sound?)
+        if (fileExt === '.png') {
+            img = nativeImage.createFromDataURL(contents);
+            contents = img.toPng();
+        }
+        // save As Stuff
+        // TODO: Show a dialog, but that doesn't work?
+        // TODO: What to do about encoding?
+
+        fs.writeFile(fileName + fileExt, contents, function (err, resp) {
+            if (err) {
+                console.log('Error! ', err);
+                myself.showMessage('Oh Noes!' + err);
+            } else {
+                console.log('Saved??');
+                myself.showMessage('Saved!');
+            }
+        });
+
+        // This doesn't work right now, because it's the wrong electron "context"
+        // var dialog = require('electron').dialog;
+        // dialog.showSaveDialog({ filters: [
+        //    { name: 'text', extensions: ['txt'] }
+        //   ]}, function (fileName) {
+        //   if (fileName === undefined) return;
+        //   fs.writeFile(fileName, fContents, function (err) {
+        //    dialog.showMessageBox({ message: "The file has been saved! :-)",
+        //     buttons: ["OK"] });
+        //   });
+        // });
+    };
+});
 
 // Override paths because snap content lives in snap/*
 // Our snap is served from /snap.html
-defineProxy('resourceURL', function () {
-    var args = Array.prototype.slice.call(arguments, 0);
-    return 'snap/' + args.join('/');
+defineProxy(IDE_Morph, 'resourceURL', () => {
+    return function () {
+        var args = Array.prototype.slice.call(arguments, 0);
+        return 'snap/' + args.join('/');
+    };
 });
 
 
-defineProxy('getURL', function(resourcePath) {
-    if (url.parse(resourcePath).protocol) {
-        return originalMethod('getURL')(resourcePath);
-    }
-    let filePath = path.join(__dirname, resourcePath);
-    let file = fs.readFileSync(filePath);
-    return file.toString();
+defineProxy(IDE_Morph, 'getURL', oldGetURL => {
+    return function(resourcePath) {
+        if (url.parse(resourcePath).protocol) {
+            return oldGetURL(resourcePath);
+        }
+        let filePath = path.join(__dirname, resourcePath);
+        let file = fs.readFileSync(filePath);
+        return file.toString();
+    };
 });

--- a/app/snap-app/gui.js
+++ b/app/snap-app/gui.js
@@ -84,3 +84,26 @@ defineProxy(IDE_Morph, 'getURL', oldGetURL => {
         return file.toString();
     };
 });
+
+// When Ctrl-Q (or Cmd-Q on a Mac) is pressed, close the window. We have to
+// explicitly define this behavior because Snap! captures all keyboard input.
+defineProxy(WorldMorph, 'initEventListeners', oldInitEventListeners => {
+    return function() {
+        oldInitEventListeners.call(this);
+
+        this.worldCanvas.addEventListener('keydown', evt => {
+            let pressedQuit = false;
+            if (evt.keyCode === 81) {
+                if (process.platform === 'darwin' && evt.metaKey) {
+                    pressedQuit = true;
+                } else if (evt.ctrlKey) {
+                    pressedQuit = true;
+                }
+            }
+
+            if (pressedQuit) {
+                remote.getCurrentWindow().close();
+            }
+        });
+    };
+});


### PR DESCRIPTION
Resolves #15 by causing the browser window to close when the user presses Ctrl-Q (or Cmd-Q on a Mac). This does mesh nicely with #23.

The diff is pretty tough to read as it is, so I recommend reading the two commits one at a time, or at least specifying `?w=1` in the "files" URL.